### PR TITLE
fixes few more prints and uses setuptools to find packages

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,12 +1,8 @@
 from distutils.core import setup
+from setuptools import find_packages
 setup(
   name = 'simple_rl',
-  packages = ['simple_rl', 'simple_rl.utils', 'simple_rl.mdp', 'simple_rl.mdp.oomdp',\
-  'simple_rl.planning', 'simple_rl.agents', 'simple_rl.agents.bandits', 'simple_rl.agents.func_approx', 'simple_rl.experiments', 'simple_rl.tasks',\
-  'simple_rl.tasks.chain', 'simple_rl.tasks.random', 'simple_rl.tasks.grid_world', 'simple_rl.tasks.four_room',\
-  'simple_rl.tasks.taxi', 'simple_rl.mdp.markov_game', 'simple_rl.tasks.gym',\
-  'simple_rl.tasks.grid_game', 'simple_rl.tasks.rock_paper_scissors', 'simple_rl.tasks.prisoners', \
-  'simple_rl.abstraction', 'simple_rl.abstraction.action_abs', 'simple_rl.abstraction.state_abs'],
+  packages = find_packages(),
   scripts=['simple_rl/run_experiments.py'],
   install_requires=[
       'numpy',

--- a/simple_rl/abstraction/dev_hierarch/HierarchyAgentClass.py
+++ b/simple_rl/abstraction/dev_hierarch/HierarchyAgentClass.py
@@ -17,7 +17,7 @@ class HierarchyAgent(Agent):
         self.cur_level = cur_level
         self.agent = SubAgentClass(actions=self.get_cur_actions())
         Agent.__init__(self, name=self.agent.name + "-hierarch" + name_ext, actions=self.get_cur_actions())
-    
+
     # -- Accessors --
 
     def get_num_levels(self):
@@ -49,7 +49,7 @@ class HierarchyAgent(Agent):
 
     def set_level(self, new_level):
         if new_level < 0 or new_level > self.get_num_levels():
-            print "HierarchyAgentError: the given level (" + str(new_level) +") exceeds the hierarchy height (" + str(self.get_num_levels()) + ")"
+            print("HierarchyAgentError: the given level (" + str(new_level) +") exceeds the hierarchy height (" + str(self.get_num_levels()) + ")")
             quit()
 
         self.cur_level = new_level
@@ -67,7 +67,7 @@ class HierarchyAgent(Agent):
         '''
         # Give the SA stack, ground state, and reward to the AA stack.
         return self.action_abstr_stack.act(self.agent, self.state_abstr_stack, ground_state, reward, level=self.cur_level)
-   
+
     # -- Reset --
 
     def reset(self):

--- a/simple_rl/abstraction/dev_hierarch/StateAbstractionStackClass.py
+++ b/simple_rl/abstraction/dev_hierarch/StateAbstractionStackClass.py
@@ -39,8 +39,8 @@ class StateAbstractionStack(StateAbstraction):
 
     def set_level(self, new_level):
         if new_level > self.get_num_levels() or new_level < 0:
-            print "StateAbstractionStack Error: given level (" + str(new_level) + ") is invalid. Must be between" + \
-                "0 and the number of levels in the stack (" + str(self.get_num_levels()) + ")."
+            print("StateAbstractionStack Error: given level (" + str(new_level) + ") is invalid. Must be between" + \
+                "0 and the number of levels in the stack (" + str(self.get_num_levels()) + ").")
             quit()
         self.level = new_level
 
@@ -146,8 +146,8 @@ class StateAbstractionStack(StateAbstraction):
         self.list_of_phi = self.list_of_phi[:-1]
 
     def print_state_space_sizes(self):
-        print "State Space Sizes:"
-        print "\t0", len(self.get_ground_states())
+        print("State Space Sizes:")
+        print("\t0", len(self.get_ground_states()))
 
         for i, phi in enumerate(self.list_of_phi):
-            print "\t", i + 1, len(set(phi.values()))
+            print("\t", i + 1, len(set(phi.values())))

--- a/simple_rl/abstraction/dev_hierarch/hierarchy_experiments.py
+++ b/simple_rl/abstraction/dev_hierarch/hierarchy_experiments.py
@@ -24,11 +24,11 @@ def main():
     sa_stack, aa_stack = hierarchy_helpers.make_hierarchy(environment, num_levels=3)
 
     # Debug.
-    print "\n" + ("=" * 30)
-    print "== Done making abstraction. =="
-    print "=" * 30 + "\n"
+    print("\n" + ("=" * 30))
+    print("== Done making abstraction. ==")
+    print("=" * 30 + "\n")
     sa_stack.print_state_space_sizes()
-    print "Num Action Abstractions:", len(aa_stack.get_aa_list())
+    print("Num Action Abstractions:", len(aa_stack.get_aa_list()))
 
     # ===================
     # === Make Agents ===
@@ -42,9 +42,9 @@ def main():
     dynamic_hierarch_agent = DynamicHierarchyAgent(QLearningAgent, sa_stack=sa_stack, aa_stack=aa_stack, cur_level=1, name_ext="-$d$")
     # dynamic_rmax_hierarch_agent = DynamicHierarchyAgent(RMaxAgent, sa_stack=sa_stack, aa_stack=aa_stack, cur_level=1, name_ext="-$d$")
 
-    print "\n" + ("=" * 26)
-    print "== Running experiments. =="
-    print "=" * 26 + "\n"
+    print("\n" + ("=" * 26))
+    print("== Running experiments. ==")
+    print("=" * 26 + "\n")
 
     # ======================
     # === Run Experiment ===

--- a/simple_rl/abstraction/dev_hierarch/hierarchy_helpers.py
+++ b/simple_rl/abstraction/dev_hierarch/hierarchy_helpers.py
@@ -31,7 +31,7 @@ def make_hierarchy(mdp_distr, num_levels):
     '''
 
     if num_levels <= 0:
-        print "(hiearchy_helpers.py) Error: @num_levels must be > 0 (given value: " + str(num_levels) + ")."
+        print("(hiearchy_helpers.py) Error: @num_levels must be > 0 (given value: " + str(num_levels) + ").")
         quit()
 
     sa_stack = StateAbstractionStack(list_of_phi=[])
@@ -39,9 +39,9 @@ def make_hierarchy(mdp_distr, num_levels):
     epsilon = 0.0
 
     for i in range(1, num_levels):
-        print "\n" + "=" * 20
-        print "== Making layer " + str(i + 1) + " =="
-        print "=" * 20 + "\n"
+        print("\n" + "=" * 20)
+        print("== Making layer " + str(i + 1) + " ==")
+        print("=" * 20 + "\n")
         sa_stack, aa_stack, epsilon = add_layer(mdp_distr, sa_stack, aa_stack, init_epsilon=epsilon)
         # Update MDP Distribution
 
@@ -68,7 +68,7 @@ def add_layer(mdp_distr, sa_stack, aa_stack, init_epsilon=0.0):
     epsilon, epsilon_incr = init_epsilon, 0.01
 
     while epsilon < 1.0:
-        print "Abstraction rate (epsilon):", epsilon
+        print("Abstraction rate (epsilon):", epsilon)
 
         # Set level to the largest shared between sa_stack and aa_stack.
         abstr_mdp_level = min(sa_stack.get_num_levels(), aa_stack.get_num_levels())
@@ -110,7 +110,7 @@ def add_layer_to_sa_stack(mdp_distr, sa_stack, aa_stack, epsilon):
         abstr_mdp_distr = mdp_distr
 
     # Make new phi.
-    new_sa = sa_helpers.make_multitask_sa(abstr_mdp_distr, epsilon=epsilon)    
+    new_sa = sa_helpers.make_multitask_sa(abstr_mdp_distr, epsilon=epsilon)
     new_phi = _convert_abstr_states(new_sa._phi, sa_stack.get_num_levels() + 1)
     sa_stack.add_phi(new_phi)
 
@@ -161,7 +161,7 @@ def add_layer_to_aa_stack(mdp_distr, sa_stack, aa_stack):
         return aa_stack, True
 
     next_aa = ActionAbstraction(options=next_options, prim_actions=mdp_distr.get_actions())
-    
+
     aa_stack.add_aa(next_aa)
     return aa_stack, False
 


### PR DESCRIPTION
Installed latest version and again saw a missing module error. It missed a tasks.bandit this time. Thought of using setuptools that I just read about, it seems to be working well. We can also remove unwanted modules for installation if & when required by explicitly filtering them using their name or using deliberate prefix/suffix to filter out.