### PR TITLE
changed arguments in example to fix runtime errors

### DIFF
--- a/examples/abstraction_example.py
+++ b/examples/abstraction_example.py
@@ -15,7 +15,7 @@ def main(open_plot=True):
     mdp = GridWorldMDP(width=10, height=10, init_loc=(1, 1), goal_locs=[(10, 10)])
     ql_agent = QLearningAgent(actions=mdp.get_actions())
     rand_agent = RandomAgent(actions=mdp.get_actions())
-    abstr_identity_agent = AbstractionWrapper(QLearningAgent, agent_params={"epsilon":0.9}, actions=mdp.get_actions())
+    abstr_identity_agent = AbstractionWrapper(QLearningAgent, agent_params={"epsilon":0.9, "actions":mdp.get_actions()})
 
     # Run experiment and make plot.
     run_agents_on_mdp([ql_agent, rand_agent, abstr_identity_agent], mdp, instances=5, episodes=100, steps=150, open_plot=open_plot)

--- a/examples/goal_based_options_example.py
+++ b/examples/goal_based_options_example.py
@@ -19,7 +19,7 @@ def main(open_plot=True):
     # Make goal-based option agent.
     goal_based_options = aa_helpers.make_goal_based_options(mdp_distr)
     goal_based_aa = ActionAbstraction(prim_actions=mdp_distr.get_actions(), options=goal_based_options)
-    option_agent = AbstractionWrapper(QLearningAgent, actions=mdp_distr.get_actions(), action_abstr=goal_based_aa)
+    option_agent = AbstractionWrapper(QLearningAgent, agent_params={"actions":mdp_distr.get_actions()}, action_abstr=goal_based_aa)
 
     # Run experiment and make plot.
     run_agents_lifelong([ql_agent, rand_agent, option_agent], mdp_distr, samples=10, episodes=100, steps=150, open_plot=open_plot)


### PR DESCRIPTION
The AbstractionWrapper objects created in abstraction_example.py and goal_based_options_example.py took in a named parameter called actions. Perhaps this was correct in earlier versions, but the current api calls for the actions to be passed to the AbstractionWrapper as part of the agent_params argument. One line changes to each of the mentioned python files fixed the issue.