### PR TITLE
syntax fixes

### DIFF
--- a/examples/examples_overview.ipynb
+++ b/examples/examples_overview.ipynb
@@ -339,7 +339,7 @@
    "source": [
     "from simple_rl.tasks.grid_world import GridWorldMDPClass\n",
     "\n",
-    "pblocks_mdp = GridWorldMDPClass.make_grid_world_from_file(\"pblocks_grid.txt\", randomize=False)\n",
+    "pblocks_mdp = GridWorldMDPClass.make_grid_world_from_file(\"../simple_rl/tasks/grid_world/txt_grids/pblocks_grid.txt\", randomize=False)\n",
     "pblocks_mdp.visualize_value()"
    ]
   },

--- a/simple_rl/agents/PolicyGradientAgentClass.py
+++ b/simple_rl/agents/PolicyGradientAgentClass.py
@@ -12,7 +12,7 @@ class PolicyGradientAgent(Agent):
     ''' Class for a random decision maker. '''
 
     def __init__(self, actions, name=""):
-        raise NotImplementedError("Policy Gradient has not yet been implemented.)
+        raise NotImplementedError("Policy Gradient has not yet been implemented.")
 
     def act(self, state, reward):
         '''

--- a/simple_rl/agents/RandomAgentClass.py
+++ b/simple_rl/agents/RandomAgentClass.py
@@ -10,7 +10,7 @@ class RandomAgent(Agent):
     ''' Class for a random decision maker. '''
 
     def __init__(self, actions, name=""):
-        name = "Random" if name is "" else name
+        name = "Random" if name == "" else name
         Agent.__init__(self, name=name, actions=actions)
 
     def act(self, state, reward):


### PR DESCRIPTION
Small errors I got when running the examples_overview notebook.

First, unterminated string literal in `PolicyGradientAgentClass`, fails on import:
<img width="829" alt="Screenshot 2024-02-04 at 8 55 29 AM" src="https://github.com/david-abel/simple_rl/assets/8399069/53a0b353-d13e-49e6-9226-f387f6d1eba4">

Next, syntax error on `is` vs. `==` in RandomAgentClass:

<img width="1170" alt="Screenshot 2024-02-04 at 8 56 39 AM" src="https://github.com/david-abel/simple_rl/assets/8399069/696f22d1-5f88-4461-b1d7-7f5c7b107f33">


Works fine when I add both of these in locally!
<img width="593" alt="Screenshot 2024-02-04 at 8 57 09 AM" src="https://github.com/david-abel/simple_rl/assets/8399069/14862ac5-2781-4cd3-9e4e-97996e3dca73">


